### PR TITLE
Static certname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,7 +175,7 @@ All notable changes to this project will be documented in this file.
 
 **Bugfixes**
 
-* Bugfix: agenntrun script installation
+* Bugfix: agentrun script installation
 
 **Known Issues**
 
@@ -186,5 +186,15 @@ All notable changes to this project will be documented in this file.
 **Bugfixes**
 
 * Bugfix: disable import ca resource
+
+**Known Issues**
+
+## Release 0.5.1
+
+**Features**
+
+* Added ability to setup static certname
+
+**Bugfixes**
 
 **Known Issues**

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -118,6 +118,13 @@
 # @param node_environment
 # @param runtimeout
 #
+# @param static_certname
+#   When enabled, puppet.conf main section will contain certname directive
+#
+# @param certname
+#   certname directive value (default - $facts['networking']['fqdn'])
+#   (https://www.puppet.com/docs/puppet/7/configuration.html#certname)
+#
 # @summary Setup Puppet configuration file (puppet.conf)
 #
 # @example
@@ -150,6 +157,8 @@ class puppet::config (
   Stdlib::Absolutepath $external_nodes = $puppet::params::external_nodes,
   Optional[String] $node_environment = undef,
   Optional[Puppet::TimeUnit] $runtimeout = $puppet::runtimeout,
+  Boolean $static_certname = false,
+  String  $certname = $facts['networking']['fqdn'],
 ) inherits puppet::params {
   include puppet::agent::install
   include puppet::globals
@@ -171,6 +180,7 @@ class puppet::config (
     content => template('puppet/puppet.conf.erb'),
   }
 
+  # https://www.puppet.com/docs/puppet/7/config_ssl_external_ca.html#config_puppet_server
   if $puppet_server {
     class { 'puppet::server::ca::allow':
       server    => $server,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "aursu-puppet",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "aursu",
   "summary": "Puppet server installation and setup",
   "license": "Apache-2.0",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -43,6 +43,40 @@ describe 'puppet::config' do
           .with_content(%r{^puppetlabs.services.ca.certificate-authority-service/certificate-authority-service})
       }
 
+      it {
+        is_expected.to contain_file('puppet-config')
+          .with_path('/etc/puppetlabs/puppet/puppet.conf')
+          .without_content(%r{certname})
+      }
+
+      context 'check static certname' do
+        let(:params) do
+          {
+            static_certname: true,
+          }
+        end
+
+        it {
+          is_expected.to contain_file('puppet-config')
+            .with_path('/etc/puppetlabs/puppet/puppet.conf')
+            .with_content(%r{^\[server\]\ncertname =})
+        }
+
+        context 'with defined static name' do
+          let(:params) do
+            super().merge(
+              'certname' => 'puppet-ca.domain.tld',
+            )
+          end
+  
+          it {
+            is_expected.to contain_file('puppet-config')
+              .with_path('/etc/puppetlabs/puppet/puppet.conf')
+              .with_content(%r{^\[server\]\ncertname = puppet-ca.domain.tld$})
+          }
+        end
+      end
+
       context 'check ca directive in server config for default (Puppet 7) server' do
         let(:params) do
           {

--- a/templates/puppet.conf.erb
+++ b/templates/puppet.conf.erb
@@ -54,6 +54,10 @@ report = true
 
 <% if @puppet_server -%>
 [<%= @server_section %>]
+<%   if @static_certname -%>
+<%# Default: node's fully qualified domain name -%>
+certname = <%= @certname %>
+<%   end -%>
 vardir = /opt/puppetlabs/server/data/puppetserver
 logdir = /var/log/puppetlabs/puppetserver
 rundir = /var/run/puppetlabs/puppetserver


### PR DESCRIPTION
Added ability to set a static value for the `certname` setting in `puppet.conf`